### PR TITLE
Resolução do exercício do bloco_20.4 :rocket: 

### DIFF
--- a/exercises/20.4/db.sql
+++ b/exercises/20.4/db.sql
@@ -1,0 +1,38 @@
+DROP SCHEMA IF EXISTS Pixar;
+CREATE SCHEMA Pixar;
+USE Pixar;
+
+CREATE TABLE Movies (
+  id INTEGER auto_increment PRIMARY KEY NOT NULL,
+  title VARCHAR(30) NOT NULL,
+  director VARCHAR(30) NULL,
+  year INT NOT NULL,
+  length_minutes INT NOT NULL
+);
+
+CREATE TABLE BoxOffice (
+  movie_id INTEGER,
+  FOREIGN KEY (movie_id) REFERENCES Movies (id),
+  rating DECIMAL(2,1) NOT NULL,
+  domestic_sales INT NOT NULL,
+  international_sales INT NOT NULL
+);
+
+INSERT INTO Movies(title, director, year, length_minutes)
+  VALUES ('Toy Story', 'John Lasseter', 1995, 81),
+         ('Vida de inseto', 'Andrew Staton', 1998, 95),
+         ('ratatui', 'Brad Bird', 2010, 115),
+         ('UP', 'Pete Docter', 2009, 101),
+         ('Carros', 'John Lasseter', 2006, 117),
+         ('Toy Story 2', 'John Lasseter', 1999, 93),
+         ('Valente', 'Brenda Chapman', 2012, 98);
+
+
+INSERT INTO BoxOffice(movie_id, rating, domestic_sales, international_sales)
+  VALUES (1, 8.3, 190000000, 170000000),
+         (2, 7.2, 160000000, 200600000),
+         (3, 7.9, 245000000, 239000000),
+         (4, 6.1, 330000000, 540000000),
+         (5, 7.8, 140000000, 310000000),
+         (6, 5.8, 540000000, 600000000),
+         (7, 7.5, 250000000, 190000000);

--- a/exercises/20.4/req1.sql
+++ b/exercises/20.4/req1.sql
@@ -1,0 +1,6 @@
+INSERT INTO Pixar.Movies (title, director, year, length_minutes)
+VALUES
+  ('Monstros SA', 'Pete Docter', 2001, 92),
+  ('Procurando Nemo', 'John Lasseter', 2003, 107),
+  ('Os Incríveis', 'Brad Bird', 2004, 116),
+  ('WALL-E', 'Pete Docter', 2008, 104);

--- a/exercises/20.4/req2.sql
+++ b/exercises/20.4/req2.sql
@@ -1,0 +1,3 @@
+INSERT INTO Pixar.BoxOffice (movie_id, rating, domestic_sales, international_sales)
+VALUE
+	(9, 6.8, 450000000, 370000000);

--- a/exercises/20.4/req3.sql
+++ b/exercises/20.4/req3.sql
@@ -1,0 +1,3 @@
+UPDATE Pixar.Movies
+SET director = 'Andrew Staton'
+WHERE id = 9;

--- a/exercises/20.4/req4.sql
+++ b/exercises/20.4/req4.sql
@@ -1,0 +1,3 @@
+UPDATE Pixar.Movies
+SET title = 'Ratatouille', `year` = '2007'
+WHERE id = 3;

--- a/exercises/20.4/req5.sql
+++ b/exercises/20.4/req5.sql
@@ -1,0 +1,5 @@
+INSERT INTO Pixar.BoxOffice (movie_id, rating, domestic_sales, international_sales)
+  VALUES
+		(8, 8.5, 300000000, 250000000),
+    (10, 7.4, 460000000, 510000000),
+    (11, 9.9, 290000000, 280000000);

--- a/exercises/20.4/req6.sql
+++ b/exercises/20.4/req6.sql
@@ -1,0 +1,5 @@
+DELETE FROM Pixar.BoxOffice
+WHERE movie_id = 11;
+
+DELETE FROM Pixar.Movies
+WHERE id = 11;

--- a/exercises/20.4/req7.sql
+++ b/exercises/20.4/req7.sql
@@ -1,0 +1,5 @@
+DELETE FROM Pixar.BoxOffice
+WHERE movie_id IN(2, 9);
+
+DELETE FROM Pixar.Movies
+WHERE director = 'Andrew Staton';


### PR DESCRIPTION
# Questões

## Exercício 1 : 
### Insira as produções da Pixar abaixo na tabela `Movies` :
- [x] - Monstros SA, de Pete Docter, lançado em 2001, com 92 minutos de duração.
- [x] - Procurando Nemo, de John Lasseter, lançado em 2003, com 107 minutos de duração.
- [x] - Os Incríveis, de Brad Bird, lançado em 2004, com 116 minutos de duração.
- [x] - WALL-E, de Pete Docter, lançada em 2008, com 104 minutos de duração.

## Exercício 2 :
- [x] - Procurando Nemo foi aclamado pela crítica! Foi classificado em 6.8, fez 450 milhões no mercado interno e 370 milhões no mercado internacional. Adicione as informações à tabela `BoxOffice` .

## Exercício 3 :
- [x] - O diretor do filme "Procurando Nemo" está incorreto, na verdade ele foi dirigido por Andrew Staton. Corrija esse dado utilizando o `UPDATE` .

## Exercício 4 : 
- [x] - O título do filme "Ratatouille" esta escrito de forma incorreta na tabela `Movies` , além disso, o filme foi lançado em 2007 e não em 2010. Corrija esses dados utilizando o `UPDATE` .

## Exercício 5 : 
### Insira as novas classificações abaixo na tabela `BoxOffice` , lembre-se que a coluna `movie_id` é uma foreign key referente a coluna `id` da tabela `Movies` :
- [x] - Monsters SA, classificado em 8.5, lucrou 300 milhões no mercado interno e 250 milhões no mercado internacional.
- [x] - Os Incríveis, classificado em 7.4, lucrou 460 milhões no mercado interno e 510 milhões no mercado internacional.
- [x] - WALL-E, classificado em 9.9, lucrou 290 milhões no mercado interno e 280 milhões no mercado internacional.

## Exercício 6 : 
- [x] - Exclua da tabela `Movies` o filme "WALL-E".
## Exercício 7 : 
- [x] - Exclua da tabela `Movies` todos os filmes dirigidos por "Andrew Staton".