### PR TITLE
[Bloco 33.3][Introdução a Python][Testes]

### DIFF
--- a/exercises/bloco_33/33.3/.gitignore
+++ b/exercises/bloco_33/33.3/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/exercises/bloco_33/33.3/.vscode/settings.json
+++ b/exercises/bloco_33/33.3/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true
+}

--- a/exercises/bloco_33/33.3/list_number.py
+++ b/exercises/bloco_33/33.3/list_number.py
@@ -1,0 +1,14 @@
+def list_maker(num):
+    if type(num) == str:
+        raise TypeError("Invalid value, value is not an int")
+    new_list = []
+    for index in range(1, num + 1):
+        if index % 3 == 0 and index % 5 == 0:
+            new_list.append("FizzBuzz")
+        elif index % 3 == 0:
+            new_list.append("Fizz")
+        elif index % 5 == 0:
+            new_list.append("Buzz")
+        else:
+            new_list.append(index)
+    return new_list

--- a/exercises/bloco_33/33.3/list_number.py
+++ b/exercises/bloco_33/33.3/list_number.py
@@ -1,5 +1,5 @@
 def list_maker(num):
-    if type(num) == str:
+    if type(num) != int:
         raise TypeError("Invalid value, value is not an int")
     new_list = []
     for index in range(1, num + 1):

--- a/exercises/bloco_33/33.3/test_list_maker.py
+++ b/exercises/bloco_33/33.3/test_list_maker.py
@@ -1,0 +1,50 @@
+from list_number import list_maker
+import pytest
+
+
+@pytest.fixture
+def list_whith_three():
+    return [1, 2, "Fizz"]
+
+
+@pytest.fixture
+def list_whith_five():
+    return [1, 2, "Fizz", 4, "Buzz"]
+
+
+@pytest.fixture
+def list_whith_fifteen():
+    return [
+        1,
+        2,
+        "Fizz",
+        4,
+        "Buzz",
+        "Fizz",
+        7,
+        8,
+        "Fizz",
+        "Buzz",
+        11,
+        "Fizz",
+        13,
+        14,
+        "FizzBuzz",
+    ]
+
+
+def tests_with_a_string_if_an_exception_is_returned_with_an_error_message():
+    with pytest.raises(TypeError, match="Invalid value, value is not an int"):
+        list_maker("3")
+
+
+def test_list_with_three_numbers_returns_the_expected(list_whith_three):
+    assert list_maker(3) == list_whith_three
+
+
+def test_list_with_five_numbers_returns_the_expected(list_whith_five):
+    assert list_maker(5) == list_whith_five
+
+
+def test_list_with_fifteen_numbers_returns_the_expected(list_whith_fifteen):
+    assert list_maker(15) == list_whith_fifteen


### PR DESCRIPTION
# Resolução de exercícios - bloco 33.3

<details>
  <summary>
    <h3>Exercício 1</h3>
  </summary>

- [x] Escreva um programa que retorne uma lista com os valores numéricos de `1 a N`, mas com as seguintes exceções:

Números `divisíveis por 3` deve aparecer como **"Fizz"** ao invés do número;
Números `divisíveis por 5` devem aparecer como **"Buzz"** ao invés do número;
Números `divisíveis por 3 e 5` devem aparecer como **"FizzBuzz"** ao invés do número.

Exemplo:

Entrada
```bash
3
```
Saída
```bash
[1, 2, "Fizz"]
```
</details>

<details>
  <summary>
    <h3>Exercício 2</h3>
  </summary>

- [ ] Em alguns lugares é comum lembrar um número do telefone associando seus dígitos a letras. Dessa maneira, a expressão MY LOVE significa 69 5683. Claro que existem alguns problemas, uma vez que alguns números de telefone não formam uma palavra ou uma frase, e os dígitos 1 e 0 não estão associados a nenhuma letra.
Sua tarefa é ler uma expressão e encontrar o número de telefone correspondente baseado na tabela abaixo. Uma expressão é composta por letras maiúsculas (A-Z), hifens (-) e os números 1 e 0.

```bash
Letras  ->  Número
ABC     ->  2
DEF     ->  3
GHI     ->  4
JKL     ->  5
MNO     ->  6
PQRS    ->  7
TUV     ->  8
WXYZ    ->  9
```

Exemplo:

Entrada

```bash
-HOME-SWEET-HOME
MY-MISERABLE-JOB
```

Saída

```bash
-4663-79338-4663
-647372253-562
```

> Testes: Verifique casos como entrada maior que 30 caracteres, vazia e com caracteres inválidos.

</details>

<details>
  <summary>
    <h3>Exercício 3</h3>
  </summary>

- [ ]  Exercício 3 Faça uma função que valide um e-mail, lançando uma exceção quando o valor for inválido. Endereços de e-mail válidos devem seguir as seguintes regras:
- Devem seguir o formato nomeusuario@nomewebsite.extensao;

- O nome de usuário deve conter somente letras, dígitos, traços e underscores (_);

- O nome de usuário deve iniciar com uma letra;

- O nome do website deve conter somente letras e dígitos;

- O tamanho máximo da extensão é de 3 caracteres.

</details>